### PR TITLE
Encode message to utf-8 before send

### DIFF
--- a/notifier.py
+++ b/notifier.py
@@ -43,4 +43,4 @@ class Notifier(object):
 
         for user, msg in msg_strs.iteritems():
             if msg != "":
-                NotifierFactory.getSender(user.push_method)(user, msg)
+                NotifierFactory.getSender(user.push_method)(user, msg.encode('utf-8'))


### PR DESCRIPTION
If the message contains any utf-8 characters, it needs to be encoded before send.
